### PR TITLE
Add missing packages for Libvlc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ RUN add-apt-repository -y ppa:iconnor/zoneminder-$ZM_VERS && \
 	apt-get -y install php$PHP_VERS php$PHP_VERS-fpm libapache2-mod-php$PHP_VERS php$PHP_VERS-mysql php$PHP_VERS-gd && \
 	apt-get -y install libcrypt-mysql-perl libyaml-perl libjson-perl && \
 	apt-get -y install zoneminder
-
+	apt-get -y install --no-install-recommends libvlc-dev libvlccore-dev vlc
+	
 RUN	rm /etc/mysql/my.cnf && \
 	cp /etc/mysql/mariadb.conf.d/50-server.cnf /etc/mysql/my.cnf && \
 	adduser www-data video && \


### PR DESCRIPTION
libvlc-dev libvlccore-dev vlc packages are required for use of the Libvlc source type option.

See: [](https://wiki.zoneminder.com/Ubuntu_Server_14.04_64-bit_with_Zoneminder_1.29.0_the_easy_way) 

It is still a dependency in 1.32.