### PR TITLE
Fix for commit Re-enable port 80 for special situations.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,6 @@ RUN	cd /root && \
 	chown -R www-data:www-data /usr/share/zoneminder/ && \
 	echo "ServerName localhost" >> /etc/apache2/apache2.conf && \
 	sed -i "s|^;date.timezone =.*|date.timezone = ${TZ}|" /etc/php/$PHP_VERS/apache2/php.ini && \
-	rm -f /etc/apache2/sites-enabled/000-default.conf && \
-	rm -f /etc/apache2/sites-available/000-default.conf && \
 	service mysql start && \
 	mysql -uroot < /usr/share/zoneminder/db/zm_create.sql && \
 	mysql -uroot -e "grant all on zm.* to 'zmuser'@localhost identified by 'zmpass';" && \


### PR DESCRIPTION
When you re-enabled the port 80, I think you forgot to remove:
```
rm -f /etc/apache2/sites-enabled/000-default.conf && \
rm -f /etc/apache2/sites-available/000-default.conf && \ 
```
I'll put them back, in this "fix". I'll see if I can come up with a way to disable port 80 by default and just only enable it with a flag/variable.