### PR TITLE
Added  Net::MQTT::Simple::Auth perl library

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,8 @@ RUN	rm /etc/mysql/my.cnf && \
 	perl -MCPAN -e "force install Net::WebSocket::Server" && \
 	perl -MCPAN -e "force install LWP::Protocol::https" && \
 	perl -MCPAN -e "force install Config::IniFiles" && \
-	perl -MCPAN -e "force install Net::MQTT::Simple"
+	perl -MCPAN -e "force install Net::MQTT::Simple" && \
+	perl -MCPAN -e "force install Net::MQTT::Simple::Auth"
 
 RUN	cd /root && \
 	wget www.andywilcock.com/code/cambozola/cambozola-latest.tar.gz && \


### PR DESCRIPTION
After enabling MQTT and setting username and password in the .ini file I got these messages in the log:

zmeventnotification[974]: INF [using config file: /etc/zm/zmeventnotification.ini]
zmeventnotification[974]: INF [FCM disabled. Will only send out websocket notifications]
zmeventnotification[974]: FAT [Net::MQTT::Simple::Auth missing]
zmdc[844]: ERR ['zmeventnotification.pl' exited abnormally, exit status 255]

After installing the missing library it works as expected. 