### PR TITLE
fix image naming convention, asuming image to be a local image

### DIFF
--- a/docker-run.sh
+++ b/docker-run.sh
@@ -17,4 +17,4 @@ docker run -d --name="Zoneminder" \
 -e MULTI_PORT_END="0" \
 -v "/mnt/cache/appdata/Zoneminder":"/config":rw \
 -v "/mnt/cache/appdata/Zoneminder/data":"/var/cache/zoneminder":rw \
-zoneminder
+dlandon/zoneminder


### PR DESCRIPTION
**Problem:**

error '_Unable to find image 'zoneminder:latest' locally_' when starting shell script.

**Step's to reproduce:**
- delete image 'zoneminder:latest' if you got one locally
- try to start shell script
```bash
bash docker-run.sh # or sh docker-run.sh
```

**PR:**
- fixes the naming convention of the image used in bash script to work properly