### PR TITLE
Change to master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM dlandon/baseimage
+FROM sgarzarella/baseimage-armhf
 
-LABEL maintainer="dlandon"
+MAINTAINER Stefano <stefano.garzarella@gmail.com>
 
 ENV	PHP_VERS="7.1"
 ENV ZM_VERS="1.32"


### PR DESCRIPTION
Add armhf suport and upgrade version to Master, for the moment 1.35.5, ut works out of the box with 64 bit Raspbian OS on RPI4. The only working way I know is to install this fork; https://hub.docker.com/r/sgarzarella/zoneminder-armhf and run "add-apt-repository ppa:iconnor/zoneminder-master" from inside this container. Then you have a working Zoneminder for 64 bit RPI4. 