### PR TITLE
Update utils.py

### DIFF
--- a/zmeventnotification/zmeventnotification/zmes_hook_helpers/utils.py
+++ b/zmeventnotification/zmeventnotification/zmes_hook_helpers/utils.py
@@ -335,7 +335,7 @@ def process_config(args, ctx):
                             g.logger.debug ('ignoring polygon: {} as only_triggered_zm_zones is true'.format(k), level=2)
             # now import zones if needed
             # this should be done irrespective of a monitor section
-            if g.config['only_triggered_zm_zones']:
+            if g.config['only_triggered_zm_zones'] == 'yes':
                 g.config['import_zm_zones'] = 'yes'
             if g.config['import_zm_zones'] == 'yes':
                 import_zm_zones(args.get('monitorid'), args.get('reason'))


### PR DESCRIPTION
configuration fix in utils.py

When the line "only_triggered_zm_zones=no" exists in objectconfig.ini, behavior is the same as if it were set to "yes"