### PR TITLE
Add script to set appropriate permissions on /dev/dri/* devices

### DIFF
--- a/init/07_set_dri_permissions.sh
+++ b/init/07_set_dri_permissions.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Script to set up permissions on hardware devices for GPU support.
+# Inspired by how the guys over at linuxserver did this for their Plex image:
+# https://github.com/linuxserver/docker-plex/blob/master/root/etc/cont-init.d/50-gid-video
+#
+
+echo "Granting permissions on /dev/dri/* devices..."
+
+FILES=$(find /dev/dri /dev/dvb -type c -print 2>/dev/null)
+
+for i in $FILES
+do
+	VIDEO_GID=$(stat -c '%g' "$i")
+	if id -G www-data | grep -qw "$VIDEO_GID"; then
+		echo "The www-data user already has appropriate permissions on $i"
+		touch /groupadd
+	else
+		if [ ! "${VIDEO_GID}" == '0' ]; then
+			VIDEO_NAME=$(getent group "${VIDEO_GID}" | awk -F: '{print $1}')
+			if [ -z "${VIDEO_NAME}" ]; then
+				VIDEO_NAME="video$(head /dev/urandom | tr -dc 'a-zA-Z0-9' | head -c8)"
+				groupadd "$VIDEO_NAME"
+				groupmod -g "$VIDEO_GID" "$VIDEO_NAME"
+				echo "Generated a new group called: $VIDEO_NAME with id: $VIDEO_GID to match existing group on: $i"
+			fi
+			usermod -a -G "$VIDEO_NAME" www-data
+			echo "Added user www-data to group $VIDEO_NAME so that it has permission to use: $i"
+			touch /groupadd
+		fi
+	fi
+done
+
+if [ -n "${FILES}" ] && [ ! -f "/groupadd" ]; then
+	usermod -a -G root www-data
+	echo "Added user www-data to root group for lack of a better option."
+fi


### PR DESCRIPTION
I have been investigating how to enable hardware acceleration and found that it requires the **www-data** user to have permission on **/dev/dri/*** devices. A lot of people seem to be happy to just set the permissions to 666 on **/dev/dri***, however that doesn't seem like a great solution.

In the end, I found a really elegant solution to the permissions issue that the guys over at [linuxserver used for their Plex image](https://github.com/linuxserver/docker-plex/blob/master/root/etc/cont-init.d/50-gid-video).

The script is a direct clone of their version, I have just added some echos to show what is going on and changed the user to the **www-data** one we use for ZoneMinder.

It adds the **www-data** user to the appropriate group(s) if they already exist or creates new groups as required.
This has the benefit of meaning that you don't have to mess with the permissions of the **/dev/dri/*** devices on the host.

Hope this makes sense.

FYI, this is my first PR to an open source project, so apologies if I missed any steps or etiquette.